### PR TITLE
Review search api wrapper so that it searches on the items tag parameter rather than title

### DIFF
--- a/widgets/Gallery/Widget.js
+++ b/widgets/Gallery/Widget.js
@@ -20,6 +20,11 @@ define([
 			startup: function() {
 				this.inherited(arguments);
 				
+				this._injectPanelsIntoWidget();
+				this._retrieveSearchParameters();
+				this.resize();
+			},
+			_injectPanelsIntoWidget:function(){
 				var searchUri = this.config.portalApiUri + "/" + this.config.searchPath;
 				
 				this._home = new HomeWidget();
@@ -34,7 +39,6 @@ define([
 				
 				this._categories = new ItemParametersWidget();
 				this._categories.title = "Categories";
-				this._categories.type = "category";
 				this._categories.baseUri = searchUri;
 				this._categories.pageSize = 6;
 				this._categories.mapItemUrls = this.config.mapItemUrls;
@@ -45,7 +49,6 @@ define([
 				
 				this._organisations = new ItemParametersWidget();
 				this._organisations.title = "Organisations";
-				this._organisations.type = "org";
 				this._organisations.baseUri = searchUri;
 				this._organisations.pageSize = 6;
 				this._organisations.mapItemUrls = this.config.mapItemUrls;
@@ -64,9 +67,6 @@ define([
 				this._tags.placeAt(this);
 				this._tags.on("showPanelEvent", lang.hitch(this, this._showPanel));
 				this._configureAsPanel(this._tags.domNode);
-				
-				this._configureSearchElements();
-				this.resize();
 			},
 			_showPanel:function(panelName){
 				this._removePanelFocus(this._home.domNode);
@@ -93,7 +93,7 @@ define([
 			_setPanelFocus:function(panelNode){
 				domClass.add(panelNode, "view-stack-focus");
 			},
-			_configureSearchElements:function(){
+			_retrieveSearchParameters:function(){
 			
 				var baseUri = this.config.portalApiUri;
 				
@@ -122,7 +122,6 @@ define([
 				this._organisations.resize();
 				this._tags.resize();
 			}		
-	});
-
+		});
 	}
 );

--- a/widgets/Gallery/css/style.css
+++ b/widgets/Gallery/css/style.css
@@ -271,7 +271,7 @@ div.dojoPage{
 }
 
 div.search-item-container {
-	line-height: 20px;
+	line-height: 25px;
 }
 
 div.search-item-container  span{

--- a/widgets/Gallery/widgets/ItemParameters/widget.js
+++ b/widgets/Gallery/widgets/ItemParameters/widget.js
@@ -15,7 +15,6 @@ define([
 		return declare('ParameterWidget',[_WidgetBase, _TemplatedMixin],{
 			templateString:widgetTemplate,
 			title:"Unknown",
-			type:"",
 			baseUri:"",
 			pageSize:6,
 			mapItemUrls:null,
@@ -32,7 +31,6 @@ define([
 				
 				this._resultsWidget = new ResultWidget();
 				this._resultsWidget.baseUri = this.baseUri;
-				this._resultsWidget.type = this.type;
 				this._resultsWidget.pageSize = this.pageSize;
 				this._resultsWidget.mapItemUrls = this.mapItemUrls;
 				this._resultsWidget.map = this.map;
@@ -72,7 +70,7 @@ define([
 				
 				this._resultsWidget.clearResults();
 				this._resultsWidget.updatePagination = true;
-				this._resultsWidget.searchText = parameter.Title;
+				this._resultsWidget.searchText = parameter.Tag;
 				this._resultsWidget.searchMapsAndApps();
 				
 				this._showResults();

--- a/widgets/Gallery/widgets/Result/js/MapGallerySearch.js
+++ b/widgets/Gallery/widgets/Result/js/MapGallerySearch.js
@@ -19,14 +19,7 @@ define([
 				var parameters = "";
 				
 				if(this.searchText){
-					
-					parameters = this.searchText;
-					
-					if(this.type){
-						parameters = this.type + ":" + parameters;
-					}
-					
-					parameters = "SearchText=[" + parameters + "]&";
+					parameters = "SearchText=[" + this.searchText + "]&";
 				}
 				
 				requestUri += parameters;


### PR DESCRIPTION
Update search so that categories and organisations search based on the items tag parameter. This saves having to deal with types and anomolies coming from the ArcGIS Online extract.
